### PR TITLE
UI improvements

### DIFF
--- a/BDRC/MVVM/view.py
+++ b/BDRC/MVVM/view.py
@@ -319,12 +319,22 @@ class AppView(QWidget):
         _data = list(_data.values())
 
         if _data is not None and len(_data) > 0:
+            # Get currently selected OCR model from the pipeline
+            current_model = None
+            if self.ocr_pipeline is not None and self.ocr_pipeline.ocr_model_config is not None:
+                # Find the model with matching config
+                for model in self._settingsview_model.get_ocr_models():
+                    if model.config == self.ocr_pipeline.ocr_model_config:
+                        current_model = model
+                        break
+            
             batch_dialog = BatchOCRDialog(
                 data=_data,
                 ocr_pipeline=self.ocr_pipeline,
                 ocr_models=self._settingsview_model.get_ocr_models(),
                 ocr_settings=self._settingsview_model.get_ocr_settings(),
-                threadpool=self.threadpool
+                threadpool=self.threadpool,
+                current_model=current_model  # Pass the currently selected model
             )
             batch_dialog.sign_ocr_result.connect(self.update_ocr_result)
 

--- a/BDRC/Styles.py
+++ b/BDRC/Styles.py
@@ -2,6 +2,12 @@ import resources
 
 
 DARK = """
+    /* Global button styles */
+
+    QPushButton:hover {
+        border-color: #ffad00;
+    }
+
     QFrame#ImageGallery {
         background-color: #1d1c1c;
     }
@@ -69,10 +75,18 @@ DARK = """
         padding: 4px 4px 4px 4px;
     }
 
+    QComboBox#ModelSelection:hover {
+        border: 2px solid #ffad00;
+    }
+
     QPushButton#MenuButton {
         background-color: #172832;
         border: 1px solid #1d1d1d;
         border-radius: 4px;
+    }
+
+    QPushButton#MenuButton:hover {
+        border: 1px solid #ffad00;
     }
 
     QPushButton#CanvasToolButton {
@@ -82,10 +96,10 @@ DARK = """
         padding: 4px 4px 4px;
     }
 
-    QPushButton#MenuButton::QIcon {
-        color: #d73449;
+    QPushButton#CanvasToolButton:hover {
+        border: 2px solid #ffad00;
     }
-  
+
     QPushButton#TextToolsButton {
         color: #ffffff;
         background-color: #3f3f3f;
@@ -95,6 +109,7 @@ DARK = """
 
     QPushButton#TextToolsButton:hover {
         color: #ffad00;
+        border: 2px solid #ffad00;
     }
 
     QDialog#ExportDialog {
@@ -132,6 +147,7 @@ DARK = """
 
             QPushButton::hover {
                 color: #ffad00;
+                border: 1px solid #ffad00;
             }
     }
 
@@ -169,6 +185,7 @@ DARK = """
 
     QPushButton#DialogButton:hover {
         color: #ffad00;
+        border: 1px solid #ffad00;
     }
 
     QPushButton#SmallDialogButton {
@@ -181,6 +198,7 @@ DARK = """
 
     QPushButton#SmallDialogButton:hover {
         color: #ffad00;
+        border: 1px solid #ffad00;
     }
 
     QRadioButton#OptionsRadio {
@@ -209,7 +227,7 @@ DARK = """
         width: 100px;
     }
 
-      QLabel#OptionsExplanation {
+    QLabel#OptionsExplanation {
         color: #CCCCCC;
         font-size: 11px;
         font-style: italic;
@@ -231,7 +249,7 @@ DARK = """
         border: 1px solid white;
         border-radius: 4px;
     }
-       
+
     QLineEdit#DialogLineEdit {
         color: #ffffff;
         background-color: #474747;
@@ -316,6 +334,12 @@ DARK = """
             width: 200px;
             padding: 5px;
             background-color: #A40021;
+            border-radius: 4px;
+        }
+
+        QPushButton:hover {
+            border: 1px solid #ffad00;
+            color: #ffad00;
         }
     }
 

--- a/BDRC/Widgets/Buttons.py
+++ b/BDRC/Widgets/Buttons.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QIcon, QEnterEvent, QPixmap, QColor
+from PySide6.QtGui import QIcon, QEnterEvent, QPixmap, QColor, QCursor
 from PySide6.QtWidgets import QPushButton
 
 
@@ -28,6 +28,9 @@ class MenuButton(QPushButton):
         self.default_color = "#ffffff"
         self.highlight_color = "#F2CD9B"
         self.is_active = False
+
+        # Set pointing hand cursor
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
 
         self.set_default_icon()
 
@@ -87,3 +90,6 @@ class TextToolsButton(QPushButton):
 
         self.setFixedHeight(self.height)
         self.setFixedWidth(self.width)
+
+        # Set pointing hand cursor
+        self.setCursor(Qt.CursorShape.PointingHandCursor)

--- a/BDRC/Widgets/Layout.py
+++ b/BDRC/Widgets/Layout.py
@@ -1,6 +1,7 @@
 import os
 from uuid import UUID
 from typing import List
+from PySide6.QtCore import Qt
 from BDRC.Data import Encoding, OCRLine, OCRLineUpdate, Platform
 from BDRC.Utils import get_filename
 from BDRC.Data import OCRData, OCRModel
@@ -9,7 +10,7 @@ from BDRC.Widgets.Buttons import MenuButton, TextToolsButton
 from BDRC.MVVM.viewmodel import DataViewModel, SettingsViewModel
 from BDRC.Widgets.Dialogs import TextInputDialog
 
-from PySide6.QtCore import Qt, Signal, QPoint, QPointF, QSize, QEvent, QRectF, QThreadPool
+from PySide6.QtCore import Signal, QPoint, QPointF, QSize, QEvent, QRectF, QThreadPool
 from PySide6.QtGui import (
     QBrush,
     QColor,
@@ -164,6 +165,7 @@ class ToolBox(QWidget):
         self.model_selection = QComboBox()
         self.model_selection.setFixedHeight(int(self.icon_size * 0.75))
         self.model_selection.setObjectName("ModelSelection")
+        self.model_selection.setCursor(Qt.CursorShape.PointingHandCursor)
 
         if self.ocr_models is not None and len(self.ocr_models) > 0:
             for model in self.ocr_models:

--- a/BDRC/Widgets/Layout.py
+++ b/BDRC/Widgets/Layout.py
@@ -993,8 +993,8 @@ class ImageGallery(QFrame):
         self.setObjectName("ImageGallery")
         self.setContentsMargins(0, 0, 0, 0)
         self.setMinimumHeight(600)
-        self.setMinimumWidth(180)
-        self.setMaximumWidth(420)
+        self.setMinimumWidth(250)
+        self.setMaximumWidth(500)
         self.import_dialog = None
         self.execution_dir = execution_dir
 

--- a/BDRC/Widgets/Layout.py
+++ b/BDRC/Widgets/Layout.py
@@ -227,13 +227,30 @@ class ToolBox(QWidget):
         self.s_on_select_model.emit(self.ocr_models[index])
 
     def update_ocr_models(self, ocr_models: List[OCRModel]):
+        # Remember currently selected model name before clearing
+        current_model_name = None
+        if self.model_selection.currentIndex() >= 0 and self.ocr_models is not None:
+            current_model_name = self.ocr_models[self.model_selection.currentIndex()].name
+
         self.ocr_models = ocr_models
 
         if self.ocr_models is not None and len(self.ocr_models) > 0:
+            # Block signals temporarily to avoid triggering model reload when restoring selection
+            self.model_selection.blockSignals(True)
             self.model_selection.clear()
 
             for model in self.ocr_models:
                 self.model_selection.addItem(model.name)
+            
+            # Restore previously selected model if it exists
+            if current_model_name is not None:
+                for i, model in enumerate(self.ocr_models):
+                    if model.name == current_model_name:
+                        self.model_selection.setCurrentIndex(i)
+                        break
+            
+            # Re-enable signals after we've set everything up
+            self.model_selection.blockSignals(False)
 
 
 class PageSwitcher(QFrame):


### PR DESCRIPTION
A few minor improvements in the UI :

- Make the sidebar wider to prevent the horizontal scroll line from showing up (was the case on my MacBook)
- Make the buttons nicer (orange border) and with pointer cursor
- Don't forget the selected model when opening and closing the settings modal
- Use the already selected model when opening the batch processing modal

Those changes (along with those of https://github.com/buda-base/tibetan-ocr-app/pull/31) can be previewed in this build : https://github.com/jerefrer/tibetan-ocr-app/actions/runs/14199083555