### PR TITLE
Fix checkbox text contrast in export dialog

### DIFF
--- a/BDRC/Widgets/Dialogs/export_dialog.py
+++ b/BDRC/Widgets/Dialogs/export_dialog.py
@@ -137,7 +137,11 @@ class ExportDialog(QDialog):
             color: #ffffff;
 
             QLabel {
-                color: #000000;
+                color: #ffffff;
+            }
+
+            QCheckBox {
+                color: #ffffff;
             }
             """
         )


### PR DESCRIPTION
Fixes issue #57 (UI contrast bug)

Changes QLabel and QCheckBox text color from black to white for proper visibility on dark background in export dialog.